### PR TITLE
add formatted scientific name to taxons in connected taxons

### DIFF
--- a/Prod.Domain/FA4Vurdering.cs
+++ b/Prod.Domain/FA4Vurdering.cs
@@ -56,6 +56,9 @@ namespace Prod.Domain
         [JsonConverter(typeof(JsonHelpers.CrazyIntJsonConverter))]
         public int TaxonID { get; set; }
         public string ScientificName { get; set; }
+
+        public string ScientificNameFormatted { get; set; }
+        
         //[JsonNumberHandling(JsonNumberHandling.AllowReadingFromString)]
         [JsonConverter(typeof(JsonHelpers.CrazyIntJsonConverter))]
         public int ScientificNameId { get; set; }

--- a/Public.Domain/FA2023.cs
+++ b/Public.Domain/FA2023.cs
@@ -14,6 +14,7 @@ namespace Public.Domain
         public string Id { get; set; }
         public int TaxonID { get; set; }
         public string ScientificName { get; set; }
+        public string ScientificNameFormatted { get; set; }
         public int ScientificNameId { get; set; }
 
         public string ScientificNameAuthor { get; set; }

--- a/SwissKnife/Database/ImportDataService.cs
+++ b/SwissKnife/Database/ImportDataService.cs
@@ -574,6 +574,7 @@ namespace SwissKnife.Database
                     TaxonID = from.TaxonId,
                     TaxonRank = from.EvaluatedScientificNameRank,
                     ScientificName = from.EvaluatedScientificName,
+                    ScientificNameFormatted = from.EvaluatedScientificNameFormatted,
                     ScientificNameId = (int)from.EvaluatedScientificNameId,
                     AssessmentId = from.Id
                 }, new CTaxon()
@@ -581,6 +582,7 @@ namespace SwissKnife.Database
                     TaxonID = to.TaxonId,
                     TaxonRank = to.EvaluatedScientificNameRank,
                     ScientificName = to.EvaluatedScientificName,
+                    ScientificNameFormatted = from.EvaluatedScientificNameFormatted,
                     ScientificNameId = (int)to.EvaluatedScientificNameId,
                     AssessmentId = to.Id
                 }));

--- a/SwissKnife/Database/ImportDataServiceHelper.cs
+++ b/SwissKnife/Database/ImportDataServiceHelper.cs
@@ -162,6 +162,7 @@ internal static class ImportDataServiceHelper
             TaxonRank = from.EvaluatedScientificNameRank,
             ScientificName = from.EvaluatedScientificName,
             ScientificNameId = (int)from.EvaluatedScientificNameId,
+            ScientificNameFormatted = from.EvaluatedScientificNameFormatted,
             AssessmentId = from.Id
         };
     }


### PR DESCRIPTION
Legger til formatert vitenskapelig navn til takson i ConnectedTaxons da vi trenger denne for å vise de korrekte navnene på takson som er vurdert sammen i FA. 